### PR TITLE
Provide Marshaler interface (#151)

### DIFF
--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -52,6 +52,9 @@ func tomlValueStringRepresentation(v interface{}) (string, error) {
 		return strconv.FormatFloat(value, 'f', -1, 32), nil
 	case string:
 		return "\"" + encodeTomlString(value) + "\"", nil
+	case []byte:
+		b, _ := v.([]byte)
+		return tomlValueStringRepresentation(string(b))
 	case bool:
 		if value {
 			return "true", nil


### PR DESCRIPTION
The toml.Marhshaler interface allows marshalling custom objects implementing
the interface. Design based off json.Marshaler.